### PR TITLE
Fix: Allow ticker to be passed as an argument to historical analyzer

### DIFF
--- a/historical_analyzer.py
+++ b/historical_analyzer.py
@@ -70,11 +70,20 @@ def find_stage_transitions(ticker: str, period_to_analyze: int = 252):
 
     return stage_transitions
 
+import sys
+
 def main():
     """
     メインの実行関数
     """
-    ticker_to_analyze = "DFLI"
+    if len(sys.argv) > 1:
+        ticker_to_analyze = sys.argv[1]
+    else:
+        # デフォルトのティッカー、またはエラーメッセージを表示
+        print("エラー: 分析するティッカーシンボルをコマンドライン引数として指定してください。")
+        print("例: python historical_analyzer.py AAPL")
+        return
+
     find_stage_transitions(ticker_to_analyze)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The historical_analyzer.py script previously had a hardcoded ticker symbol ("DFLI"), which prevented the analysis of other stocks via the command line.

This change modifies the script to read the ticker symbol from a command-line argument, making it a more flexible and reusable tool for analyzing the historical stage transitions of any given stock. If no argument is provided, it will print a usage message.