### PR TITLE
feat: Add status column to base analysis output

### DIFF
--- a/run_base_analyzer.py
+++ b/run_base_analyzer.py
@@ -69,6 +69,9 @@ def run_base_analysis(output_filename='base_analysis_results.csv'):
                 # ベースカウンティング
                 base_count = len(base_start_events)
 
+                # 最終状態に基づいてステータスを設定
+                status = '上昇中' if base_analyzer.state == 'WAITING_FOR_SEPARATION' else '-'
+
                 results.append({
                     'Ticker': ticker,
                     'Exchange': exchange,
@@ -77,6 +80,7 @@ def run_base_analysis(output_filename='base_analysis_results.csv'):
                     'Resistance Price': f"{resistance_price:.2f}",
                     'Days Since Resistance': days_since_resistance,
                     'Minervini Criteria Met': criteria_met,
+                    'Status': status,
                 })
 
         # 結果をCSVファイルとTradingViewリストに出力


### PR DESCRIPTION
This commit adds a 'Status' column to the CSV output of the base analysis. The status is set to '上昇中' (Rising) if a stock has broken out of a base but has not yet achieved the 20% price separation required to start a new base count. This provides clearer insight into the current state of stocks that have recently broken out.