### PR TITLE
fix: Make analyzer loop robust to individual ticker errors

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -30,6 +30,10 @@ def fetch_stock_data(ticker: str, benchmark_ticker: str = "SPY", period: str = "
             progress=False
         )
 
+        # yfinanceが予期せぬ形式（MultiIndexでないDataFrameなど）を返す場合があるため、ここで検証
+        if not isinstance(data.columns, pd.MultiIndex):
+            return None, None
+
         if data.empty or ticker not in data.columns.get_level_values(1):
             return None, None
 


### PR DESCRIPTION
This commit refactors the error handling in 'run_base_analyzer.py' to prevent the entire analysis process from crashing when an error occurs for a single ticker. The main 'try...except' block has been moved inside the 'for' loop that iterates through each stock. Now, if any exception occurs during data fetching or analysis for a specific ticker, the error will be logged, that ticker will be skipped, and the process will continue with the next ticker in the list. This significantly improves the stability and resilience of the screening process when dealing with large, potentially noisy datasets.