### PR TITLE
feat: Optimize analysis pipeline by removing redundant scans

### DIFF
--- a/screener.py
+++ b/screener.py
@@ -287,7 +287,11 @@ def main():
     print("追加分析: Base Analyzerを実行します...")
     print("=" * 70)
     try:
-        run_base_analysis(output_filename=base_analyzer_output_filename)
+        # ステージ2の分析結果をインプットとして渡すことで、処理を効率化
+        run_base_analysis(
+            output_filename=base_analyzer_output_filename,
+            input_filename=stage_output_filename
+        )
     except Exception as e:
         print(f"エラー: Base Analyzerの実行中にエラーが発生しました: {e}")
 


### PR DESCRIPTION
This commit refactors the analysis workflow to improve efficiency. Previously, 'run_base_analyzer.py' would re-scan all stocks from 'stock.csv' to find Stage 2 tickers, even after 'screener.py' had already created a filtered list.

Now, 'run_base_analyzer.py' is enhanced to accept an optional 'input_filename'. 'screener.py' leverages this by passing its output (the daily list of Stage 2 stocks) as the input for the base analysis. This eliminates the redundant second scan, significantly speeding up the overall process and creating a more logical data pipeline.