### PR TITLE
fix: Change status label to English to prevent encoding errors

### DIFF
--- a/run_base_analyzer.py
+++ b/run_base_analyzer.py
@@ -91,7 +91,7 @@ def run_base_analysis(output_filename='base_analysis_results.csv', input_filenam
                 base_count = len(base_start_events)
 
                 # 最終状態に基づいてステータスを設定
-                status = '上昇中' if base_analyzer.state == 'WAITING_FOR_SEPARATION' else '-'
+                status = 'Rising' if base_analyzer.state == 'WAITING_FOR_SEPARATION' else '-'
 
 
                 results.append({


### PR DESCRIPTION
This commit changes the "Status" column value in the base analysis output from the Japanese "上昇中" to the English "Rising". This change resolves a character encoding issue where the Japanese characters were not displaying correctly in the final CSV file on some systems.