### PR TITLE
Replace yfinance with FinancialModelingPrep API

### DIFF
--- a/FMP_API_SETUP.md
+++ b/FMP_API_SETUP.md
@@ -1,0 +1,222 @@
+# FinancialModelingPrep API セットアップガイド
+
+## 概要
+
+StageAlgoは、yfinanceからFinancialModelingPrep (FMP) APIに移行しました。FMP APIは、より安定した株価データとファンダメンタルデータを提供します。
+
+## なぜFMP APIに移行したのか？
+
+1. **信頼性の向上**: yfinanceはYahoo FinanceのWebスクレイピングに依存しており、頻繁にエラーが発生していました
+2. **データの豊富さ**: FMP APIは、株価データに加えて、財務諸表、EPS、マーケットキャップなど、豊富なファンダメンタルデータを提供します
+3. **公式API**: FMP APIは公式のAPIであり、長期的なサポートが期待できます
+
+## APIキーの取得方法
+
+### 1. FMPアカウントの作成
+
+1. [FinancialModelingPrep](https://site.financialmodelingprep.com/) にアクセス
+2. 右上の「Sign Up」をクリック
+3. メールアドレスとパスワードを入力してアカウントを作成
+
+### 2. APIキーの取得
+
+1. ログイン後、ダッシュボードに移動
+2. 「Dashboard」→「API Keys」を選択
+3. APIキーが表示されます（例: `abc123def456ghi789jkl012mno345pq`）
+
+### 3. プランの選択
+
+あなたは **Starter Plan** を使用しています。
+
+**Starter Planの制限:**
+- 20GB/月の帯域制限（Free: 500MB/月）
+- 一部のエンドポイントでティッカー数制限あり
+- 月額: 約$14-15（詳細は[料金ページ](https://site.financialmodelingprep.com/pricing-plans)を確認）
+
+**無料プラン (Free Plan) でも試用可能:**
+- 500MB/月の帯域制限
+- 250 API calls/day
+- まずは無料プランで試してから、必要に応じてStarterプランにアップグレード可能
+
+## APIキーの設定方法
+
+### オプション1: 環境変数に設定（推奨）
+
+#### Linux/Mac:
+
+```bash
+# .bashrc または .zshrc に追加
+export FMP_API_KEY='your_api_key_here'
+
+# または、現在のセッションのみで設定
+export FMP_API_KEY='your_api_key_here'
+```
+
+#### Windows (PowerShell):
+
+```powershell
+# 現在のセッションのみ
+$env:FMP_API_KEY='your_api_key_here'
+
+# 永続的に設定（システム環境変数）
+[System.Environment]::SetEnvironmentVariable('FMP_API_KEY','your_api_key_here','User')
+```
+
+#### Windows (コマンドプロンプト):
+
+```cmd
+set FMP_API_KEY=your_api_key_here
+```
+
+### オプション2: .envファイルを使用
+
+プロジェクトルートに `.env` ファイルを作成:
+
+```bash
+# .env
+FMP_API_KEY=your_api_key_here
+```
+
+そして、Pythonコードで `python-dotenv` を使用:
+
+```python
+from dotenv import load_dotenv
+load_dotenv()
+```
+
+## テスト方法
+
+APIキーが正しく設定されているか確認:
+
+```bash
+# 環境変数の確認
+echo $FMP_API_KEY  # Linux/Mac
+echo %FMP_API_KEY%  # Windows
+
+# テストスクリプトの実行
+python fmp_data_fetcher.py
+```
+
+成功すると、AAPLの株価データが表示されます:
+
+```
+Testing FMP Data Fetcher...
+API Key found: abc123def45...
+
+1. Testing historical price data for AAPL...
+
+AAPL Historical Data (last 5 rows):
+            Open    High     Low   Close      Volume  Adj Close
+date
+2024-11-01  150.0  152.5  149.5  151.2  50000000.0      151.2
+...
+
+2. Testing quote data for AAPL...
+Current Price: $151.50
+Volume: 50,000,000
+Market Cap: $2,500,000,000,000
+
+3. Testing profile data for AAPL...
+Company: Apple Inc.
+Sector: Technology
+Industry: Consumer Electronics
+Market Cap: $2,500,000,000,000
+
+Test completed!
+```
+
+## トラブルシューティング
+
+### エラー: "FMP API Key is required"
+
+環境変数 `FMP_API_KEY` が設定されていません。
+
+**解決策:**
+1. 環境変数を設定（上記参照）
+2. ターミナルを再起動して環境変数を再読み込み
+
+### エラー: "API request failed: 401 Unauthorized"
+
+APIキーが無効または期限切れです。
+
+**解決策:**
+1. FMPダッシュボードで新しいAPIキーを生成
+2. 環境変数を更新
+
+### エラー: "API request failed: 429 Too Many Requests"
+
+API呼び出し制限に達しました。
+
+**解決策:**
+1. Free Planの場合: Starter Planにアップグレード
+2. Starter Planの場合: リクエスト頻度を下げる、またはPremium Planにアップグレード
+
+### データが取得できない（空のDataFrame）
+
+ティッカーシンボルが間違っているか、FMP APIがそのティッカーをサポートしていません。
+
+**解決策:**
+1. ティッカーシンボルを確認（例: AAPL, MSFT, GOOGL）
+2. FMP APIのドキュメントで対応ティッカーを確認
+
+## FMP API リファレンス
+
+### 主要なエンドポイント
+
+| エンドポイント | 説明 | 使用例 |
+|---------------|------|--------|
+| `/historical-price-full/{ticker}` | 株価の履歴データ | `fetcher.get_historical_price('AAPL')` |
+| `/quote/{ticker}` | リアルタイムクォート | `fetcher.get_quote('AAPL')` |
+| `/profile/{ticker}` | 企業プロフィール（セクター、マーケットキャップなど） | `fetcher.get_profile('AAPL')` |
+| `/key-metrics/{ticker}` | 主要財務指標（P/E、EPS、ROEなど） | `fetcher.get_key_metrics('AAPL')` |
+| `/income-statement/{ticker}` | 損益計算書（EPSデータ含む） | `fetcher.get_income_statement('AAPL')` |
+| `/earnings-surprises/{ticker}` | 四半期決算サプライズ | `fetcher.get_earnings_surprises('AAPL')` |
+
+### 公式ドキュメント
+
+- [FMP API Documentation](https://site.financialmodelingprep.com/developer/docs)
+- [料金プラン](https://site.financialmodelingprep.com/pricing-plans)
+- [FAQ](https://site.financialmodelingprep.com/faqs)
+
+## 使用例
+
+### 基本的な使用方法
+
+```python
+from fmp_data_fetcher import FMPDataFetcher
+
+# FMPフェッチャーの初期化
+fetcher = FMPDataFetcher()
+
+# 株価の履歴データを取得
+df = fetcher.get_historical_price('AAPL', from_date='2024-01-01', to_date='2024-12-31')
+print(df.head())
+
+# リアルタイムクォート
+quote = fetcher.get_quote('AAPL')
+print(f"現在価格: ${quote['price']}")
+
+# 企業プロフィール
+profile = fetcher.get_profile('AAPL')
+print(f"セクター: {profile['sector']}")
+print(f"マーケットキャップ: ${profile['mktCap']:,}")
+```
+
+### data_fetcherを使用（既存コードとの互換性）
+
+```python
+from data_fetcher import fetch_stock_data
+
+# yfinanceと同じインターフェース
+stock_df, benchmark_df = fetch_stock_data('AAPL', period='1y')
+print(stock_df.tail())
+```
+
+## まとめ
+
+1. FMPアカウントを作成してAPIキーを取得
+2. 環境変数 `FMP_API_KEY` を設定
+3. `python fmp_data_fetcher.py` でテスト
+4. 既存のコード（`market_dashboard.py`、`oratnek_screeners.py`など）はそのまま動作します
+
+問題が発生した場合は、[FMP FAQ](https://site.financialmodelingprep.com/faqs) または [StageAlgo Issue](https://github.com/turnDeep/StageAlgo/issues) で質問してください。

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,73 +1,15 @@
-import yfinance as yf
+"""
+Data Fetcher - FinancialModelingPrep API版
+
+yfinanceからFinancialModelingPrep APIに移行しました。
+既存のコードとの互換性を保つため、関数インターフェースは維持しています。
+"""
+
+# FMPデータフェッチャーを使用
+from fmp_data_fetcher import fetch_stock_data
+
+# 後方互換性のため、元のインポートも残す
 import pandas as pd
-from curl_cffi.requests import Session
-
-def fetch_stock_data(ticker: str, benchmark_ticker: str = "SPY", period: str = "5y", interval: str = "1d", fetch_benchmark: bool = True):
-    """
-    yfinanceを使用して株価データを取得します。yfinanceの出力形式のばらつきに対応。
-
-    Args:
-        ticker (str): 株式ティッカーシンボル。
-        benchmark_ticker (str, optional): ベンチマークのティッカー。デフォルトは "SPY"。
-        period (str, optional): データ期間。デフォルトは "5y"。
-        interval (str, optional): データ間隔。デフォルトは "1d"。
-        fetch_benchmark (bool, optional): ベンチマークデータも同時に取得するかどうか。デフォルトは True。
-
-    Returns:
-        tuple[pd.DataFrame | None, pd.DataFrame | None]: (stock_data, benchmark_data)。
-    """
-    session = Session(impersonate="chrome110")
-
-    tickers_to_download = [ticker]
-    # tickerとbenchmark_tickerが同じ場合（SPY自体の取得時など）に重複させない
-    if fetch_benchmark and ticker.upper() != benchmark_ticker.upper():
-        tickers_to_download.append(benchmark_ticker)
-
-    try:
-        data = yf.download(
-            tickers=tickers_to_download,
-            period=period,
-            interval=interval,
-            session=session,
-            progress=False,
-            group_by='ticker' # 常にtickerでグループ化し、MultiIndex出力を強制
-        )
-
-        if data.empty:
-            return None, None
-
-        # MultiIndexでない場合はエラーとして扱う
-        if not isinstance(data.columns, pd.MultiIndex):
-            # yfinanceが何らかの理由で期待通りに動作しなかった場合
-            if len(tickers_to_download) == 1:
-                stock_data = data.copy()
-                stock_data.dropna(inplace=True)
-                return stock_data, None
-            return None, None
-
-
-        # 目的のティッカーデータが存在するか確認
-        if ticker not in data.columns.get_level_values(0):
-            return None, None
-
-        stock_data = data[ticker].copy()
-        stock_data.dropna(inplace=True)
-        if stock_data.empty:
-            return None, None
-
-        benchmark_data = None
-        if fetch_benchmark:
-            if ticker.upper() == benchmark_ticker.upper():
-                # 自身がベンチマークなので、データをコピー
-                benchmark_data = stock_data.copy()
-            elif benchmark_ticker in data.columns.get_level_values(0):
-                benchmark_data = data[benchmark_ticker].copy()
-                benchmark_data.dropna(inplace=True)
-
-        return stock_data, benchmark_data
-
-    except Exception as e:
-        return None, None
 
 if __name__ == '__main__':
     # (テストコードは変更なし)

--- a/fmp_data_fetcher.py
+++ b/fmp_data_fetcher.py
@@ -1,0 +1,336 @@
+"""
+FinancialModelingPrep API Data Fetcher
+
+yfinanceの代替として、FinancialModelingPrep APIを使用してデータを取得します。
+
+環境変数 FMP_API_KEY に APIキーを設定する必要があります。
+FMP Starter Planの制限:
+- 20GB/月の帯域制限
+- 一部のエンドポイントでティッカー数制限あり
+
+公式ドキュメント: https://site.financialmodelingprep.com/developer/docs
+"""
+
+import os
+import requests
+import pandas as pd
+from datetime import datetime, timedelta
+from typing import Dict, List, Tuple, Optional
+import time
+
+
+class FMPDataFetcher:
+    """FinancialModelingPrep API Data Fetcher"""
+
+    BASE_URL = "https://financialmodelingprep.com/api/v3"
+    STABLE_URL = "https://financialmodelingprep.com/stable"
+
+    def __init__(self, api_key: Optional[str] = None):
+        """
+        Initialize FMP Data Fetcher
+
+        Args:
+            api_key: FMP API Key (環境変数 FMP_API_KEY から自動取得可能)
+        """
+        self.api_key = api_key or os.getenv('FMP_API_KEY')
+        if not self.api_key:
+            raise ValueError(
+                "FMP API Key is required. Set FMP_API_KEY environment variable "
+                "or pass api_key parameter."
+            )
+
+        # データキャッシュ
+        self.cache = {}
+
+    def _make_request(self, url: str, params: Optional[Dict] = None) -> Dict:
+        """
+        Make API request with error handling
+
+        Args:
+            url: API endpoint URL
+            params: Query parameters
+
+        Returns:
+            JSON response as dict
+        """
+        if params is None:
+            params = {}
+
+        params['apikey'] = self.api_key
+
+        try:
+            response = requests.get(url, params=params, timeout=30)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            print(f"API request failed: {e}")
+            return {}
+
+    def get_historical_price(
+        self,
+        ticker: str,
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None
+    ) -> pd.DataFrame:
+        """
+        Get historical price data
+
+        Args:
+            ticker: Stock ticker symbol
+            from_date: Start date (YYYY-MM-DD format)
+            to_date: End date (YYYY-MM-DD format)
+
+        Returns:
+            DataFrame with OHLCV data
+        """
+        cache_key = f"hist_{ticker}_{from_date}_{to_date}"
+        if cache_key in self.cache:
+            return self.cache[cache_key]
+
+        url = f"{self.BASE_URL}/historical-price-full/{ticker}"
+
+        params = {}
+        if from_date:
+            params['from'] = from_date
+        if to_date:
+            params['to'] = to_date
+
+        data = self._make_request(url, params)
+
+        if not data or 'historical' not in data:
+            return pd.DataFrame()
+
+        df = pd.DataFrame(data['historical'])
+
+        if df.empty:
+            return pd.DataFrame()
+
+        # データ整形
+        df['date'] = pd.to_datetime(df['date'])
+        df.set_index('date', inplace=True)
+        df.sort_index(inplace=True)
+
+        # 列名を大文字に変換（yfinance互換）
+        df.rename(columns={
+            'open': 'Open',
+            'high': 'High',
+            'low': 'Low',
+            'close': 'Close',
+            'volume': 'Volume',
+            'adjClose': 'Adj Close'
+        }, inplace=True)
+
+        # 必要な列のみ保持
+        required_cols = ['Open', 'High', 'Low', 'Close', 'Volume']
+        if 'Adj Close' in df.columns:
+            required_cols.append('Adj Close')
+
+        df = df[required_cols]
+
+        self.cache[cache_key] = df
+        return df
+
+    def get_quote(self, ticker: str) -> Dict:
+        """
+        Get real-time quote data
+
+        Args:
+            ticker: Stock ticker symbol
+
+        Returns:
+            Quote data as dict
+        """
+        url = f"{self.BASE_URL}/quote/{ticker}"
+        data = self._make_request(url)
+
+        if data and isinstance(data, list) and len(data) > 0:
+            return data[0]
+        return {}
+
+    def get_profile(self, ticker: str) -> Dict:
+        """
+        Get company profile (includes market cap, sector, etc.)
+
+        Args:
+            ticker: Stock ticker symbol
+
+        Returns:
+            Company profile data
+        """
+        cache_key = f"profile_{ticker}"
+        if cache_key in self.cache:
+            return self.cache[cache_key]
+
+        url = f"{self.BASE_URL}/profile/{ticker}"
+        data = self._make_request(url)
+
+        if data and isinstance(data, list) and len(data) > 0:
+            profile = data[0]
+            self.cache[cache_key] = profile
+            return profile
+        return {}
+
+    def get_key_metrics(self, ticker: str, period: str = 'annual', limit: int = 10) -> List[Dict]:
+        """
+        Get key financial metrics (EPS, P/E, etc.)
+
+        Args:
+            ticker: Stock ticker symbol
+            period: 'annual' or 'quarter'
+            limit: Number of periods to retrieve
+
+        Returns:
+            List of key metrics
+        """
+        url = f"{self.BASE_URL}/key-metrics/{ticker}"
+        params = {'period': period, 'limit': limit}
+        data = self._make_request(url, params)
+
+        return data if isinstance(data, list) else []
+
+    def get_income_statement(self, ticker: str, period: str = 'quarter', limit: int = 4) -> List[Dict]:
+        """
+        Get income statement (for EPS data)
+
+        Args:
+            ticker: Stock ticker symbol
+            period: 'annual' or 'quarter'
+            limit: Number of periods to retrieve
+
+        Returns:
+            List of income statements
+        """
+        url = f"{self.BASE_URL}/income-statement/{ticker}"
+        params = {'period': period, 'limit': limit}
+        data = self._make_request(url, params)
+
+        return data if isinstance(data, list) else []
+
+    def get_earnings_surprises(self, ticker: str) -> List[Dict]:
+        """
+        Get earnings surprises (actual vs estimated EPS)
+
+        Args:
+            ticker: Stock ticker symbol
+
+        Returns:
+            List of earnings surprises
+        """
+        url = f"{self.BASE_URL}/earnings-surprises/{ticker}"
+        data = self._make_request(url)
+
+        return data if isinstance(data, list) else []
+
+
+def fetch_stock_data(
+    ticker: str,
+    benchmark_ticker: str = "SPY",
+    period: str = "5y",
+    interval: str = "1d",
+    fetch_benchmark: bool = True
+) -> Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]:
+    """
+    FMP APIを使用して株価データを取得します（yfinance互換インターフェース）
+
+    Args:
+        ticker: 株式ティッカーシンボル
+        benchmark_ticker: ベンチマークのティッカー（デフォルト: "SPY"）
+        period: データ期間（"1y", "2y", "5y" など）
+        interval: データ間隔（現在は "1d" のみサポート）
+        fetch_benchmark: ベンチマークデータも同時に取得するかどうか
+
+    Returns:
+        tuple[pd.DataFrame | None, pd.DataFrame | None]: (stock_data, benchmark_data)
+    """
+    try:
+        fetcher = FMPDataFetcher()
+
+        # 期間を日数に変換
+        period_days = {
+            '1mo': 30,
+            '3mo': 90,
+            '6mo': 180,
+            '1y': 365,
+            '2y': 730,
+            '5y': 1825,
+            '10y': 3650,
+        }
+
+        days = period_days.get(period, 1825)  # デフォルト5年
+        from_date = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d')
+        to_date = datetime.now().strftime('%Y-%m-%d')
+
+        # 株価データ取得
+        stock_data = fetcher.get_historical_price(ticker, from_date, to_date)
+
+        if stock_data.empty:
+            return None, None
+
+        stock_data.dropna(inplace=True)
+
+        # ベンチマークデータ取得
+        benchmark_data = None
+        if fetch_benchmark:
+            if ticker.upper() == benchmark_ticker.upper():
+                # 自身がベンチマーク
+                benchmark_data = stock_data.copy()
+            else:
+                benchmark_data = fetcher.get_historical_price(benchmark_ticker, from_date, to_date)
+                if benchmark_data is not None and not benchmark_data.empty:
+                    benchmark_data.dropna(inplace=True)
+
+        return stock_data, benchmark_data
+
+    except Exception as e:
+        print(f"Error fetching data for {ticker}: {e}")
+        return None, None
+
+
+if __name__ == '__main__':
+    # テストコード
+    print("Testing FMP Data Fetcher...")
+
+    # APIキーの確認
+    api_key = os.getenv('FMP_API_KEY')
+    if not api_key:
+        print("ERROR: FMP_API_KEY environment variable is not set")
+        print("Please set your API key: export FMP_API_KEY='your_api_key_here'")
+        exit(1)
+
+    print(f"API Key found: {api_key[:10]}...")
+
+    # テスト用ティッカー
+    test_ticker = 'AAPL'
+    print(f"\n1. Testing historical price data for {test_ticker}...")
+    stock_df, benchmark_df = fetch_stock_data(test_ticker, period='1y')
+
+    if stock_df is not None:
+        print(f"\n{test_ticker} Historical Data (last 5 rows):")
+        print(stock_df.tail())
+        print(f"\nShape: {stock_df.shape}")
+    else:
+        print(f"Failed to fetch data for {test_ticker}")
+
+    if benchmark_df is not None:
+        print(f"\nSPY Benchmark Data (last 5 rows):")
+        print(benchmark_df.tail())
+
+    # Quote データのテスト
+    print(f"\n2. Testing quote data for {test_ticker}...")
+    fetcher = FMPDataFetcher()
+    quote = fetcher.get_quote(test_ticker)
+    if quote:
+        print(f"Current Price: ${quote.get('price', 'N/A')}")
+        print(f"Volume: {quote.get('volume', 'N/A'):,}")
+        print(f"Market Cap: ${quote.get('marketCap', 0):,}")
+
+    # Profile データのテスト
+    print(f"\n3. Testing profile data for {test_ticker}...")
+    profile = fetcher.get_profile(test_ticker)
+    if profile:
+        print(f"Company: {profile.get('companyName', 'N/A')}")
+        print(f"Sector: {profile.get('sector', 'N/A')}")
+        print(f"Industry: {profile.get('industry', 'N/A')}")
+        print(f"Market Cap: ${profile.get('mktCap', 0):,}")
+
+    print("\nTest completed!")

--- a/oratnek_screeners.py
+++ b/oratnek_screeners.py
@@ -9,16 +9,17 @@ IBD (Investor's Business Daily) 手法に基づく6つのスクリーニング�
 4. Top 2% RS Rating - RS Rating上位2%かつトレンドが完璧
 5. 4% Bullish Yesterday - 昨日4%以上上昇
 6. Healthy Chart Watch List - 健全なチャート形状を持つ高品質銘柄
+
+yfinanceからFinancialModelingPrep APIに移行しました。
 """
 
 import pandas as pd
 import numpy as np
 from typing import Dict, List, Optional, Tuple
 from datetime import datetime, timedelta
-import yfinance as yf
-from curl_cffi.requests import Session
 
 from data_fetcher import fetch_stock_data
+from fmp_data_fetcher import FMPDataFetcher
 from indicators import calculate_all_basic_indicators
 from rs_calculator import RSCalculator
 


### PR DESCRIPTION
- FMP API用のデータフェッチャーを追加（fmp_data_fetcher.py）
- data_fetcher.py、market_dashboard.py、oratnek_screeners.pyをFMP APIに移行
- FMP API セットアップガイドを追加（FMP_API_SETUP.md）
- yfinanceの制約を解消し、より安定したデータソースに移行

主な変更点：
1. fmp_data_fetcher.py: FMP APIのラッパークラスを実装
   - 株価履歴データ、リアルタイムクォート、企業プロフィール、財務指標の取得
   - yfinance互換のインターフェースを提供

2. data_fetcher.py: FMP版に完全移行
   - 既存のコードとの互換性を保つため、関数インターフェースは維持

3. market_dashboard.py: yf.download()をFMP APIに置き換え
   - FMPDataFetcherクラスを使用してデータ取得

4. oratnek_screeners.py: yfinanceインポートを削除
   - FMPDataFetcherを使用するよう更新

5. FMP_API_SETUP.md: 詳細なセットアップガイド
   - APIキー取得方法
   - 環境変数設定方法
   - トラブルシューティング

環境変数 FMP_API_KEY の設定が必要です。
詳細は FMP_API_SETUP.md を参照してください。