### PR TITLE
Set up development container environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,50 @@
+# Use an official Python runtime as a parent image
+FROM python:3.12-slim
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    wget \
+    vim \
+    nano \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory in the container
+WORKDIR /workspace
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Install development tools
+RUN pip install --no-cache-dir \
+    pytest \
+    pytest-cov \
+    black \
+    flake8 \
+    mypy \
+    pylint \
+    autopep8 \
+    ipython \
+    jupyter
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+# Set Python to run in unbuffered mode
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Default command
+CMD ["/bin/bash"]

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,147 @@
+# Dev Container セットアップガイド
+
+このプロジェクトは VS Code の Dev Container 機能に対応しています。
+
+## 必要なもの
+
+- [Visual Studio Code](https://code.visualstudio.com/)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop)
+- VS Code 拡張機能: [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+## 使い方
+
+### 1. Dev Container を開く
+
+1. このプロジェクトを VS Code で開く
+2. コマンドパレット (Ctrl+Shift+P / Cmd+Shift+P) を開く
+3. "Dev Containers: Reopen in Container" を選択
+4. コンテナのビルドと起動を待つ（初回は数分かかります）
+
+### 2. 環境変数の設定
+
+FMP API を使用する場合は、環境変数を設定してください：
+
+```bash
+export FMP_API_KEY='your_fmp_api_key_here'
+```
+
+または、`.env` ファイルをプロジェクトルートに作成：
+
+```bash
+FMP_API_KEY=your_fmp_api_key_here
+```
+
+### 3. 開発開始
+
+Dev Container が起動すると、以下が自動的にインストールされます：
+
+- Python 3.12
+- プロジェクトの依存関係 (requirements.txt)
+- 開発ツール (pytest, black, flake8, mypy, pylint)
+- VS Code 拡張機能 (Python, Pylance, Jupyter など)
+
+## 主な機能
+
+### インストール済みツール
+
+- **Python 開発環境**: Python 3.12 + pip
+- **テストフレームワーク**: pytest, pytest-cov
+- **コードフォーマッター**: black, autopep8
+- **リンター**: flake8, pylint, mypy
+- **対話型シェル**: IPython
+- **Jupyter Notebook**: サポート済み
+
+### VS Code 拡張機能
+
+- Python
+- Pylance (高度な型チェック)
+- Black Formatter
+- Jupyter
+- Python Environment Manager
+- autoDocstring
+
+### ポートフォワーディング
+
+以下のポートが自動的にフォワードされます：
+
+- `8050`: ダッシュボード用
+- `8888`: Jupyter Notebook 用
+
+## 開発ワークフロー
+
+### パッケージのインストール
+
+```bash
+# 開発モードでインストール
+pip install -e .
+```
+
+### テストの実行
+
+```bash
+# すべてのテストを実行
+pytest
+
+# カバレッジレポート付き
+pytest --cov=stagealgo
+```
+
+### コードフォーマット
+
+```bash
+# Black でフォーマット
+black .
+
+# フォーマットチェックのみ
+black --check .
+```
+
+### リンターの実行
+
+```bash
+# Flake8
+flake8 .
+
+# Pylint
+pylint stagealgo/
+
+# MyPy (型チェック)
+mypy stagealgo/
+```
+
+### スクリーナーの実行
+
+```bash
+# スクリーナーを実行
+stagealgo-screener --input stagealgo/data/stock.csv --output results/
+
+# ダッシュボードを起動
+stagealgo-dashboard
+```
+
+## トラブルシューティング
+
+### コンテナが起動しない
+
+1. Docker Desktop が起動していることを確認
+2. VS Code を再起動
+3. コマンドパレット → "Dev Containers: Rebuild Container"
+
+### パッケージが見つからない
+
+```bash
+# 依存関係を再インストール
+pip install -r requirements.txt
+pip install -e .
+```
+
+### 権限エラー
+
+コンテナは root ユーザーで実行されています。権限の問題が発生した場合は、
+`devcontainer.json` の `remoteUser` を変更してください。
+
+## その他
+
+- コンテナ内でも Git 操作が可能です
+- Docker socket がマウントされているため、Docker-in-Docker も可能です
+- ワークスペースは `/workspace` にマウントされます

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,75 @@
+{
+  "name": "StageAlgo Dev Container",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+
+  // Features
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  // VSCode settings
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": true,
+        "python.formatting.autopep8Path": "/usr/local/bin/autopep8",
+        "python.formatting.blackPath": "/usr/local/bin/black",
+        "python.formatting.yapfPath": "/usr/local/bin/yapf",
+        "python.linting.banditPath": "/usr/local/bin/bandit",
+        "python.linting.flake8Path": "/usr/local/bin/flake8",
+        "python.linting.mypyPath": "/usr/local/bin/mypy",
+        "python.linting.pycodestylePath": "/usr/local/bin/pycodestyle",
+        "python.linting.pydocstylePath": "/usr/local/bin/pydocstyle",
+        "python.linting.pylintPath": "/usr/local/bin/pylint",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestPath": "/usr/local/bin/pytest",
+        "[python]": {
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          }
+        },
+        "files.exclude": {
+          "**/__pycache__": true,
+          "**/*.pyc": true
+        }
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter",
+        "ms-toolsai.jupyter",
+        "donjayamanne.python-environment-manager",
+        "njpwerner.autodocstring"
+      ]
+    }
+  },
+
+  // Container environment
+  "remoteEnv": {
+    "PYTHONUNBUFFERED": "1",
+    "PYTHONDONTWRITEBYTECODE": "1"
+  },
+
+  // Lifecycle scripts
+  "postCreateCommand": "pip install -e . && pip install pytest black flake8 mypy pylint autopep8",
+
+  // Mount docker socket for docker-in-docker if needed
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ],
+
+  // Forward ports if needed for dashboards
+  "forwardPorts": [8050, 8888],
+
+  // Run as root to avoid permission issues (can be changed to non-root if preferred)
+  "remoteUser": "root"
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# FMP API Key
+# Get your API key from https://financialmodelingprep.com/developer/docs/
+FMP_API_KEY=your_fmp_api_key_here
+
+# Optional: Python environment settings
+PYTHONUNBUFFERED=1
+PYTHONDONTWRITEBYTECODE=1

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ cython_debug/
 stage_history/
 stage_history_*/
 *.json
+!.devcontainer/*.json
 
 # Screener output files
 [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-*.csv

--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ export FMP_API_KEY='your_fmp_api_key_here'
 
 ### 開発環境のセットアップ
 
+#### オプション1: Dev Container を使用（推奨）
+
+VS Code の Dev Container 機能を使用すると、一貫した開発環境を簡単に構築できます。
+
+**必要なもの:**
+- [Visual Studio Code](https://code.visualstudio.com/)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop)
+- VS Code 拡張機能: [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+**手順:**
+1. このリポジトリをクローン
+2. VS Code でプロジェクトを開く
+3. コマンドパレット (Ctrl+Shift+P / Cmd+Shift+P) を開く
+4. "Dev Containers: Reopen in Container" を選択
+5. コンテナのビルドと起動を待つ（初回は数分かかります）
+
+詳細は [.devcontainer/README.md](.devcontainer/README.md) を参照してください。
+
+#### オプション2: ローカル環境でのセットアップ
+
 ```bash
 # 依存ライブラリのインストール
 pip install -r requirements.txt


### PR DESCRIPTION
- Add .devcontainer/devcontainer.json with Python 3.12 configuration
- Add .devcontainer/Dockerfile with development tools
- Add .devcontainer/README.md with detailed setup instructions
- Add .env.example for environment variable template
- Update README.md with Dev Container setup instructions
- Update .gitignore to allow .devcontainer/*.json files

This enables developers to quickly start working on the project with a consistent development environment using VS Code's Dev Container feature.