### PR TITLE
Update API rate limit to 750 calls per minute

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 # Get your API key from https://financialmodelingprep.com/developer/docs/
 FMP_API_KEY=your_fmp_api_key_here
 
+# FMP API Rate Limit (requests per minute)
+# Starter Plan: 300, Premium Plan: 750, Professional Plan: 1500
+FMP_RATE_LIMIT=750
+
 # Optional: Python environment settings
 PYTHONUNBUFFERED=1
 PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
- Update default rate limit from 300 to 750 calls/min
- Add FMP_RATE_LIMIT environment variable configuration
- Support configurable rate limits via .env file
- Update .env.example with rate limit options for different plans