### PR TITLE
Fix financialmodelingprep data and migrate to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ stage_history_*/
 [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-*.txt
 sampled_stocks.csv
 *.html
+data/

--- a/fmp_data_fetcher.py
+++ b/fmp_data_fetcher.py
@@ -17,21 +17,38 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Tuple, Optional
 import time
 from curl_cffi.requests import Session, errors
+from fmp_sqlite_manager import FMPSQLiteManager
 
 
 class FMPDataFetcher:
-    """FinancialModelingPrep API Data Fetcher"""
+    """FinancialModelingPrep API Data Fetcher with SQLite caching"""
 
     BASE_URL = "https://financialmodelingprep.com/api/v3"
     STABLE_URL = "https://financialmodelingprep.com/stable"
 
-    def __init__(self, api_key: Optional[str] = None, rate_limit: Optional[int] = None):
+    # 非個別銘柄リスト（SQLiteでキャッシュするティッカー）
+    NON_STOCK_TICKERS = {
+        # Market
+        'SPY', 'QQQ', 'MAGS', 'RSP', 'QQEW', 'IWM',
+        # Sectors
+        'EPOL', 'EWG', 'GLD', 'KWEB', 'IEV', 'ITA', 'CIBR', 'IBIT', 'BLOK',
+        'IAI', 'NLR', 'XLF', 'XLU', 'TAN', 'UFO', 'XLP', 'FFTY', 'INDA',
+        'ARKW', 'XLK', 'XLE', 'IPO', 'SOXX', 'MDY', 'SCHD', 'DIA', 'ITB',
+        'USO', 'IBB',
+        # Macro
+        'NYICDX', '^VIX', 'TLT'
+    }
+
+    def __init__(self, api_key: Optional[str] = None, rate_limit: Optional[int] = None,
+                 use_sqlite: bool = True, db_path: str = 'data/fmp_data.db'):
         """
         Initialize FMP Data Fetcher
 
         Args:
             api_key: FMP API Key (環境変数 FMP_API_KEY から自動取得可能)
             rate_limit: API rate limit per minute (環境変数 FMP_RATE_LIMIT から自動取得可能, デフォルト: 750)
+            use_sqlite: Use SQLite for caching (default: True)
+            db_path: SQLite database path
         """
         self.api_key = api_key or os.getenv('FMP_API_KEY')
         if not self.api_key:
@@ -43,10 +60,14 @@ class FMPDataFetcher:
         # レート制限の設定（環境変数から取得、デフォルトは750 req/min - Premium Plan）
         self.rate_limit = rate_limit or int(os.getenv('FMP_RATE_LIMIT', '750'))
 
-        # データキャッシュ
+        # データキャッシュ（メモリ）
         self.cache = {}
         self.session = Session(impersonate="chrome110")
         self.request_timestamps = []
+
+        # SQLite Manager
+        self.use_sqlite = use_sqlite
+        self.sqlite_manager = FMPSQLiteManager(db_path) if use_sqlite else None
 
     def _enforce_rate_limit(self):
         """Enforce the configured API rate limit per minute."""
@@ -93,7 +114,7 @@ class FMPDataFetcher:
         to_date: Optional[str] = None
     ) -> pd.DataFrame:
         """
-        Get historical price data
+        Get historical price data with SQLite caching
 
         Args:
             ticker: Stock ticker symbol
@@ -103,10 +124,20 @@ class FMPDataFetcher:
         Returns:
             DataFrame with OHLCV data
         """
+        # SQLiteキャッシュを確認（非個別銘柄のみ）
+        if self.use_sqlite and ticker in self.NON_STOCK_TICKERS and self.sqlite_manager:
+            cached_df = self.sqlite_manager.get_historical_prices(
+                ticker, from_date, to_date, max_age_days=1
+            )
+            if cached_df is not None:
+                return cached_df
+
+        # メモリキャッシュを確認
         cache_key = f"hist_{ticker}_{from_date}_{to_date}"
         if cache_key in self.cache:
             return self.cache[cache_key]
 
+        # APIからデータ取得
         url = f"{self.BASE_URL}/historical-price-full/{ticker}"
 
         params = {}
@@ -147,12 +178,17 @@ class FMPDataFetcher:
 
         df = df[required_cols]
 
+        # SQLiteに保存（非個別銘柄のみ）
+        if self.use_sqlite and ticker in self.NON_STOCK_TICKERS and self.sqlite_manager:
+            self.sqlite_manager.save_historical_prices(ticker, df)
+
+        # メモリキャッシュに保存
         self.cache[cache_key] = df
         return df
 
     def get_quote(self, ticker: str) -> Dict:
         """
-        Get real-time quote data
+        Get real-time quote data with SQLite caching
 
         Args:
             ticker: Stock ticker symbol
@@ -160,16 +196,27 @@ class FMPDataFetcher:
         Returns:
             Quote data as dict
         """
+        # SQLiteキャッシュを確認（非個別銘柄のみ）
+        if self.use_sqlite and ticker in self.NON_STOCK_TICKERS and self.sqlite_manager:
+            cached_quote = self.sqlite_manager.get_quote(ticker, max_age_minutes=15)
+            if cached_quote is not None:
+                return cached_quote
+
+        # APIからデータ取得
         url = f"{self.BASE_URL}/quote/{ticker}"
         data = self._make_request(url)
 
         if data and isinstance(data, list) and len(data) > 0:
-            return data[0]
+            quote = data[0]
+            # SQLiteに保存（非個別銘柄のみ）
+            if self.use_sqlite and ticker in self.NON_STOCK_TICKERS and self.sqlite_manager:
+                self.sqlite_manager.save_quote(ticker, quote)
+            return quote
         return {}
 
     def get_profile(self, ticker: str) -> Dict:
         """
-        Get company profile (includes market cap, sector, etc.)
+        Get company profile with SQLite caching
 
         Args:
             ticker: Stock ticker symbol
@@ -177,15 +224,27 @@ class FMPDataFetcher:
         Returns:
             Company profile data
         """
+        # SQLiteキャッシュを確認（非個別銘柄のみ）
+        if self.use_sqlite and ticker in self.NON_STOCK_TICKERS and self.sqlite_manager:
+            cached_profile = self.sqlite_manager.get_profile(ticker, max_age_days=30)
+            if cached_profile is not None:
+                return cached_profile
+
+        # メモリキャッシュを確認
         cache_key = f"profile_{ticker}"
         if cache_key in self.cache:
             return self.cache[cache_key]
 
+        # APIからデータ取得
         url = f"{self.BASE_URL}/profile/{ticker}"
         data = self._make_request(url)
 
         if data and isinstance(data, list) and len(data) > 0:
             profile = data[0]
+            # SQLiteに保存（非個別銘柄のみ）
+            if self.use_sqlite and ticker in self.NON_STOCK_TICKERS and self.sqlite_manager:
+                self.sqlite_manager.save_profile(ticker, profile)
+            # メモリキャッシュに保存
             self.cache[cache_key] = profile
             return profile
         return {}

--- a/fmp_sqlite_manager.py
+++ b/fmp_sqlite_manager.py
@@ -1,0 +1,482 @@
+"""
+FMP Data SQLite Manager
+
+FinancialModelingPrep APIから取得したデータをSQLiteで管理します。
+主にMarket Ticker、Sectors Ticker、Macro Tickerなどの非個別銘柄データを対象とします。
+
+機能:
+- 価格データの保存・取得
+- Quote データの保存・取得
+- Profile データの保存・取得
+- 自動キャッシュ管理
+"""
+
+import sqlite3
+import pandas as pd
+import json
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+from pathlib import Path
+
+
+class FMPSQLiteManager:
+    """FMP Data SQLite Manager"""
+
+    def __init__(self, db_path: str = 'data/fmp_data.db'):
+        """
+        Initialize SQLite Manager
+
+        Args:
+            db_path: SQLite database file path
+        """
+        self.db_path = db_path
+        # データディレクトリを作成
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._create_tables()
+
+    def _get_connection(self):
+        """Get database connection"""
+        return sqlite3.connect(self.db_path)
+
+    def _create_tables(self):
+        """Create database tables if they don't exist"""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        # Historical price data table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS historical_prices (
+                ticker TEXT NOT NULL,
+                date TEXT NOT NULL,
+                open REAL,
+                high REAL,
+                low REAL,
+                close REAL,
+                volume INTEGER,
+                adj_close REAL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (ticker, date)
+            )
+        ''')
+
+        # Quote data table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS quotes (
+                ticker TEXT PRIMARY KEY,
+                price REAL,
+                change_percentage REAL,
+                change REAL,
+                day_low REAL,
+                day_high REAL,
+                year_high REAL,
+                year_low REAL,
+                market_cap INTEGER,
+                volume INTEGER,
+                avg_volume INTEGER,
+                open REAL,
+                previous_close REAL,
+                eps REAL,
+                pe REAL,
+                data TEXT,
+                updated_at TEXT NOT NULL
+            )
+        ''')
+
+        # Company profile table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS profiles (
+                ticker TEXT PRIMARY KEY,
+                company_name TEXT,
+                sector TEXT,
+                industry TEXT,
+                market_cap INTEGER,
+                description TEXT,
+                ceo TEXT,
+                website TEXT,
+                data TEXT,
+                updated_at TEXT NOT NULL
+            )
+        ''')
+
+        # Create indexes for faster queries
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_hist_ticker ON historical_prices(ticker)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_hist_date ON historical_prices(date)')
+
+        conn.commit()
+        conn.close()
+
+    def save_historical_prices(self, ticker: str, df: pd.DataFrame):
+        """
+        Save historical price data to SQLite
+
+        Args:
+            ticker: Stock ticker symbol
+            df: DataFrame with OHLCV data (index: date)
+        """
+        if df.empty:
+            return
+
+        conn = self._get_connection()
+
+        # DataFrameをリセットしてdateを列にする
+        df_copy = df.copy()
+        df_copy.reset_index(inplace=True)
+
+        # 列名を標準化
+        df_copy.rename(columns={
+            'date': 'date',
+            'Open': 'open',
+            'High': 'high',
+            'Low': 'low',
+            'Close': 'close',
+            'Volume': 'volume',
+            'Adj Close': 'adj_close'
+        }, inplace=True)
+
+        # updated_atを追加
+        df_copy['updated_at'] = datetime.now().isoformat()
+        df_copy['ticker'] = ticker
+
+        # dateをstring形式に変換
+        df_copy['date'] = pd.to_datetime(df_copy['date']).dt.strftime('%Y-%m-%d')
+
+        # 必要な列のみ選択
+        columns = ['ticker', 'date', 'open', 'high', 'low', 'close', 'volume', 'updated_at']
+        if 'adj_close' in df_copy.columns:
+            columns.insert(-1, 'adj_close')
+
+        df_to_save = df_copy[columns]
+
+        # データベースに保存（REPLACE: 既存データを上書き）
+        df_to_save.to_sql('historical_prices', conn, if_exists='append', index=False, method='multi')
+
+        # 重複を削除（最新のupdated_atを保持）
+        cursor = conn.cursor()
+        cursor.execute('''
+            DELETE FROM historical_prices
+            WHERE rowid NOT IN (
+                SELECT MAX(rowid)
+                FROM historical_prices
+                GROUP BY ticker, date
+            )
+        ''')
+
+        conn.commit()
+        conn.close()
+
+    def get_historical_prices(
+        self,
+        ticker: str,
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None,
+        max_age_days: int = 1
+    ) -> Optional[pd.DataFrame]:
+        """
+        Get historical price data from SQLite
+
+        Args:
+            ticker: Stock ticker symbol
+            from_date: Start date (YYYY-MM-DD)
+            to_date: End date (YYYY-MM-DD)
+            max_age_days: Maximum age of cached data in days (default: 1)
+
+        Returns:
+            DataFrame with OHLCV data or None if not found/expired
+        """
+        conn = self._get_connection()
+
+        # 基本クエリ
+        query = 'SELECT * FROM historical_prices WHERE ticker = ?'
+        params = [ticker]
+
+        # 日付フィルター
+        if from_date:
+            query += ' AND date >= ?'
+            params.append(from_date)
+        if to_date:
+            query += ' AND date <= ?'
+            params.append(to_date)
+
+        query += ' ORDER BY date ASC'
+
+        df = pd.read_sql_query(query, conn, params=params)
+        conn.close()
+
+        if df.empty:
+            return None
+
+        # キャッシュの有効期限チェック
+        latest_update = pd.to_datetime(df['updated_at'].iloc[-1])
+        if datetime.now() - latest_update > timedelta(days=max_age_days):
+            return None  # 期限切れ
+
+        # DataFrameを整形
+        df['date'] = pd.to_datetime(df['date'])
+        df.set_index('date', inplace=True)
+
+        # 列名を大文字に変換（yfinance互換）
+        df.rename(columns={
+            'open': 'Open',
+            'high': 'High',
+            'low': 'Low',
+            'close': 'Close',
+            'volume': 'Volume',
+            'adj_close': 'Adj Close'
+        }, inplace=True)
+
+        # 必要な列のみ保持
+        required_cols = ['Open', 'High', 'Low', 'Close', 'Volume']
+        if 'Adj Close' in df.columns:
+            required_cols.append('Adj Close')
+
+        return df[required_cols]
+
+    def save_quote(self, ticker: str, quote_data: Dict):
+        """
+        Save quote data to SQLite
+
+        Args:
+            ticker: Stock ticker symbol
+            quote_data: Quote data dictionary
+        """
+        if not quote_data:
+            return
+
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        cursor.execute('''
+            INSERT OR REPLACE INTO quotes (
+                ticker, price, change_percentage, change, day_low, day_high,
+                year_high, year_low, market_cap, volume, avg_volume, open,
+                previous_close, eps, pe, data, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (
+            ticker,
+            quote_data.get('price'),
+            quote_data.get('changesPercentage'),
+            quote_data.get('change'),
+            quote_data.get('dayLow'),
+            quote_data.get('dayHigh'),
+            quote_data.get('yearHigh'),
+            quote_data.get('yearLow'),
+            quote_data.get('marketCap'),
+            quote_data.get('volume'),
+            quote_data.get('avgVolume'),
+            quote_data.get('open'),
+            quote_data.get('previousClose'),
+            quote_data.get('eps'),
+            quote_data.get('pe'),
+            json.dumps(quote_data),
+            datetime.now().isoformat()
+        ))
+
+        conn.commit()
+        conn.close()
+
+    def get_quote(self, ticker: str, max_age_minutes: int = 15) -> Optional[Dict]:
+        """
+        Get quote data from SQLite
+
+        Args:
+            ticker: Stock ticker symbol
+            max_age_minutes: Maximum age of cached data in minutes (default: 15)
+
+        Returns:
+            Quote data dictionary or None if not found/expired
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        cursor.execute('SELECT * FROM quotes WHERE ticker = ?', (ticker,))
+        row = cursor.fetchone()
+        conn.close()
+
+        if not row:
+            return None
+
+        # キャッシュの有効期限チェック
+        updated_at = datetime.fromisoformat(row[16])  # updated_at column
+        if datetime.now() - updated_at > timedelta(minutes=max_age_minutes):
+            return None  # 期限切れ
+
+        # JSON文字列からデータを復元
+        return json.loads(row[15])  # data column
+
+    def save_profile(self, ticker: str, profile_data: Dict):
+        """
+        Save company profile data to SQLite
+
+        Args:
+            ticker: Stock ticker symbol
+            profile_data: Profile data dictionary
+        """
+        if not profile_data:
+            return
+
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        cursor.execute('''
+            INSERT OR REPLACE INTO profiles (
+                ticker, company_name, sector, industry, market_cap,
+                description, ceo, website, data, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (
+            ticker,
+            profile_data.get('companyName'),
+            profile_data.get('sector'),
+            profile_data.get('industry'),
+            profile_data.get('mktCap'),
+            profile_data.get('description'),
+            profile_data.get('ceo'),
+            profile_data.get('website'),
+            json.dumps(profile_data),
+            datetime.now().isoformat()
+        ))
+
+        conn.commit()
+        conn.close()
+
+    def get_profile(self, ticker: str, max_age_days: int = 30) -> Optional[Dict]:
+        """
+        Get company profile data from SQLite
+
+        Args:
+            ticker: Stock ticker symbol
+            max_age_days: Maximum age of cached data in days (default: 30)
+
+        Returns:
+            Profile data dictionary or None if not found/expired
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        cursor.execute('SELECT * FROM profiles WHERE ticker = ?', (ticker,))
+        row = cursor.fetchone()
+        conn.close()
+
+        if not row:
+            return None
+
+        # キャッシュの有効期限チェック
+        updated_at = datetime.fromisoformat(row[9])  # updated_at column
+        if datetime.now() - updated_at > timedelta(days=max_age_days):
+            return None  # 期限切れ
+
+        # JSON文字列からデータを復元
+        return json.loads(row[8])  # data column
+
+    def clear_old_data(self, days: int = 30):
+        """
+        Clear old data from database
+
+        Args:
+            days: Delete data older than this many days
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        cutoff_date = (datetime.now() - timedelta(days=days)).isoformat()
+
+        cursor.execute('DELETE FROM historical_prices WHERE updated_at < ?', (cutoff_date,))
+        cursor.execute('DELETE FROM quotes WHERE updated_at < ?', (cutoff_date,))
+        cursor.execute('DELETE FROM profiles WHERE updated_at < ?', (cutoff_date,))
+
+        conn.commit()
+        conn.close()
+
+    def get_cached_tickers(self) -> List[str]:
+        """
+        Get list of tickers with cached data
+
+        Returns:
+            List of ticker symbols
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        cursor.execute('SELECT DISTINCT ticker FROM historical_prices')
+        tickers = [row[0] for row in cursor.fetchall()]
+
+        conn.close()
+        return tickers
+
+
+if __name__ == '__main__':
+    # テストコード
+    print("Testing FMP SQLite Manager...")
+
+    manager = FMPSQLiteManager()
+    print(f"Database created at: {manager.db_path}")
+
+    # テストデータ
+    test_ticker = 'SPY'
+
+    # 1. 価格データのテスト
+    print(f"\n1. Testing historical price data for {test_ticker}...")
+    test_df = pd.DataFrame({
+        'Open': [100.0, 101.0, 102.0],
+        'High': [101.0, 102.0, 103.0],
+        'Low': [99.0, 100.0, 101.0],
+        'Close': [100.5, 101.5, 102.5],
+        'Volume': [1000000, 1100000, 1200000]
+    }, index=pd.date_range('2025-01-01', periods=3))
+    test_df.index.name = 'date'
+
+    manager.save_historical_prices(test_ticker, test_df)
+    print("✓ Price data saved")
+
+    retrieved_df = manager.get_historical_prices(test_ticker)
+    if retrieved_df is not None:
+        print("✓ Price data retrieved")
+        print(retrieved_df)
+    else:
+        print("✗ Failed to retrieve price data")
+
+    # 2. Quoteデータのテスト
+    print(f"\n2. Testing quote data for {test_ticker}...")
+    test_quote = {
+        'price': 102.5,
+        'changesPercentage': 1.5,
+        'change': 1.5,
+        'dayLow': 101.0,
+        'dayHigh': 103.0,
+        'marketCap': 5000000000
+    }
+
+    manager.save_quote(test_ticker, test_quote)
+    print("✓ Quote data saved")
+
+    retrieved_quote = manager.get_quote(test_ticker)
+    if retrieved_quote:
+        print("✓ Quote data retrieved")
+        print(retrieved_quote)
+    else:
+        print("✗ Failed to retrieve quote data")
+
+    # 3. Profileデータのテスト
+    print(f"\n3. Testing profile data for {test_ticker}...")
+    test_profile = {
+        'companyName': 'SPDR S&P 500 ETF Trust',
+        'sector': 'ETF',
+        'industry': 'Index ETF',
+        'mktCap': 5000000000
+    }
+
+    manager.save_profile(test_ticker, test_profile)
+    print("✓ Profile data saved")
+
+    retrieved_profile = manager.get_profile(test_ticker)
+    if retrieved_profile:
+        print("✓ Profile data retrieved")
+        print(retrieved_profile)
+    else:
+        print("✗ Failed to retrieve profile data")
+
+    # 4. キャッシュされたティッカーのリスト
+    print("\n4. Testing cached tickers...")
+    cached_tickers = manager.get_cached_tickers()
+    print(f"Cached tickers: {cached_tickers}")
+
+    print("\nTest completed!")

--- a/market_dashboard.py
+++ b/market_dashboard.py
@@ -531,8 +531,9 @@ class MarketDashboard:
 
                 # --- RS Rating ---
                 rs_calc = RSCalculator(indicators_df, spy_indicators)
-                rs_rating_series = rs_calc.calculate_rs_rating_series()
-                rs_rating = rs_rating_series.iloc[-1] if not rs_rating_series.empty else np.nan
+                rs_score_series = rs_calc.calculate_ibd_rs_score()
+                current_rs_score = rs_score_series.iloc[-1] if not rs_score_series.empty else 0
+                rs_rating = rs_calc.calculate_percentile_rating(current_rs_score)
 
                 # --- Relative Strength (vs SPY, 1-Year) ---
                 spy_perf_1y = ((spy_indicators['Close'].iloc[-1] - spy_indicators['Close'].iloc[-252]) / spy_indicators['Close'].iloc[-252]) * 100


### PR DESCRIPTION
- Fixed market_dashboard.py: Replace non-existent calculate_rs_rating_series() with calculate_ibd_rs_score() and calculate_percentile_rating()
- Implemented fmp_sqlite_manager.py: SQLite-based data management system for caching market/sector/macro ticker data
- Enhanced fmp_data_fetcher.py: Integrated SQLite caching for non-stock tickers (Market, Sectors, Macro)
- Added data/ directory to .gitignore

This resolves the 'RSCalculator' object has no attribute 'calculate_rs_rating_series' error and improves data caching efficiency.