### PR TITLE
Fix errors in run_dashboard.py script

### DIFF
--- a/oratnek_data_manager.py
+++ b/oratnek_data_manager.py
@@ -270,8 +270,9 @@ class OratnekDataManager:
                 'Volume': 'sum'
             }).dropna()
 
-            # 列名を小文字に統一
+            # 列名を小文字に統一し、スペースをアンダースコアに変換
             df_daily.rename(columns=str.lower, inplace=True)
+            df_daily.rename(columns={'adj close': 'adj_close'}, inplace=True)
             df_weekly.rename(columns=str.lower, inplace=True)
 
             logger.info(f"'{symbol}': Fetched {len(df_daily)} daily and {len(df_weekly)} weekly records.")
@@ -328,8 +329,8 @@ class OratnekDataManager:
 
                 if not df_daily.empty:
                     cols = ['open', 'high', 'low', 'close', 'volume']
-                    if 'adj close' in df_daily.columns:
-                        cols.append('adj close')
+                    if 'adj_close' in df_daily.columns:
+                        cols.append('adj_close')
                     cols.extend(['sma_10', 'sma_21', 'sma_50', 'sma_150', 'sma_200', 'ema_200'])
 
                     df_to_save = df_daily[cols].copy()


### PR DESCRIPTION
Fixed SQLite error "table daily_prices has no column named adj close" by:
- Renaming 'adj close' to 'adj_close' after lowercase conversion in _fetch_from_fmp()
- Updating column name check from 'adj close' to 'adj_close' in _save_to_db()

This ensures consistency between DataFrame column names and SQLite table schema, which defines the column as 'adj_close' (with underscore).