### PR TITLE
Fix TradingView Pine Script Alerts (SOXL/GDXU)

### DIFF
--- a/analysis.txt
+++ b/analysis.txt
@@ -1,0 +1,48 @@
+User asked three questions based on a screenshot:
+1. 写真のように設定したのは間違い？合ってる？ (Is the setup in the photo wrong or right?)
+2. かつで繋がずに1個ずつ設定した方がいい？ (Should I set them up individually instead of connecting them with "AND"?)
+3. SOXLで設定してるけどGDXUも設定した方がいい？ (I set it up on SOXL, should I also set it up on GDXU?)
+
+Analysis:
+1. The setup is completely WRONG. The user used "かつ" (AND) to combine four different conditions: SOX Long Entry, SOX Long Exit, GLD Long Entry, and GLD Long Exit.
+An "AND" condition means the alert will ONLY fire if ALL four events happen on the exact same bar at the exact same time. This is mathematically impossible (you can't have an Entry and Exit on the same bar simultaneously, nor are SOX and GLD likely to trigger at the exact same millisecond). So this alert will never fire.
+
+2. Yes, they MUST be set up individually.
+The user should create 4 completely separate alerts.
+Alert 1: Condition -> "SOX Long Entry". Click "Create".
+Alert 2: Condition -> "SOX Long Exit". Click "Create".
+Alert 3: Condition -> "GLD Long Entry". Click "Create".
+Alert 4: Condition -> "GLD Long Exit". Click "Create".
+
+3. Regarding SOXL vs GDXU.
+The Pine Script uses `request.security()` to explicitly fetch `INDEX:SOX` and `AMEX:GLD` data, and it also explicitly fetches `SOXL` and `GDXU` close prices.
+Because the script hardcodes the symbols using `request.security()`, the chart that the script is applied to DOES NOT MATTER for the calculations.
+Therefore, if they apply the script to the SOXL chart and create the 4 alerts there, the alerts will work perfectly for both SOXL and GDXU.
+They DO NOT need to apply the script to the GDXU chart and create another set of alerts. Doing so would just create duplicate alerts.
+
+Explanation in Japanese needs to be very clear, as the user is a beginner.
+
+Draft explanation:
+ご提示いただいた写真の設定は**「間違い」**です。このままでは一生アラートが鳴りません。
+理由と正しい設定方法を以下にまとめました。
+
+### 1. 「かつ」で繋ぐのはNG？1個ずつ設定した方がいい？
+**はい、絶対に1個ずつ（計4つの別々のアラートとして）作成してください。**
+
+写真のように「かつ（AND）」で繋いでしまうと、「SOXの買い」「SOXの売り」「GLDの買い」「GLDの売り」の**4つすべての条件が、全く同じ瞬間に同時に発生した場合のみ**鳴る設定になってしまいます。買いと売りが同時に発生することはあり得ないため、このアラートは絶対に鳴りません。
+
+**【正しい設定手順】**
+以下の手順を4回繰り返して、**4つの独立したアラート**を作成してください。
+1. アラート作成画面を開く
+2. 条件のドロップダウンから **「SOX Long Entry」のみ** を選択する（「かつ」で条件を追加しない！）
+3. トリガーを「バーの終値ごとに1回」にする
+4. 「作成」ボタンを押す
+5. 同様に、「SOX Long Exit」「GLD Long Entry」「GLD Long Exit」についても、それぞれ1から作り直す（合計4つのアラートがリストに並ぶ状態が正解です）。
+
+### 2. SOXLで設定してるけどGDXUも設定した方がいい？
+**いいえ、SOXLのチャート上だけで設定すればOKです（GDXUのチャートで二重に設定する必要はありません）。**
+
+このPine Scriptは、スクリプトの内部で自動的に「SOX（半導体）」と「GLD（金）」の両方のデータを読み込んで計算する仕組み（request.security）になっています。
+そのため、表示しているチャートが「SOXL」であっても、裏側ではGLDの計算も完璧に行われています。
+
+SOXLのチャート上で上記の4つのアラートを作成しておけば、GLD（GDXU）の売買シグナルが出た時もちゃんと通知が来ます。もしGDXUのチャートでも同じアラートを作ってしまうと、通知が2重に届いてしまうのでご注意ください。

--- a/fix_alerts.pine
+++ b/fix_alerts.pine
@@ -1,0 +1,98 @@
+// This Pine Script® code is subject to the terms of the Mozilla Public License 2.0 at https://mozilla.org/MPL/2.0/
+// © planetes0925
+
+//@version=6
+indicator("Ultimate MTF Portfolio (SOXL/GDXU)", overlay=false)
+
+// =========================================================================
+// 1. INPUTS
+// =========================================================================
+grp_tech = "Tech Signal (SOX)"
+i_tech_sym = input.symbol("NASDAQ:SOX", title="Tech Index Symbol", group=grp_tech)
+i_tech_w_len = input.int(5, title="Tech Weekly ATR Length", group=grp_tech)
+i_tech_w_mult = input.float(1.5, title="Tech Weekly ATR Mult", group=grp_tech, step=0.1)
+i_tech_d_len = input.int(14, title="Tech Daily ATR Length", group=grp_tech)
+i_tech_d_mult = input.float(4.0, title="Tech Daily ATR Mult", group=grp_tech, step=0.1)
+
+grp_gold = "Gold Signal (GLD)"
+i_gold_sym = input.symbol("AMEX:GLD", title="Gold ETF Symbol", group=grp_gold)
+i_gold_w_len = input.int(14, title="Gold Weekly ATR Length", group=grp_gold)
+i_gold_w_mult = input.float(2.0, title="Gold Weekly ATR Mult", group=grp_gold, step=0.1)
+i_gold_d_len = input.int(5, title="Gold Daily ATR Length", group=grp_gold)
+i_gold_d_mult = input.float(1.5, title="Gold Daily ATR Mult", group=grp_gold, step=0.1)
+
+// =========================================================================
+// 2. CUSTOM ATR TRAILING STOP FUNCTION (Strict RMA)
+// =========================================================================
+f_atr_ts(h, l, c, len, mult) =>
+    true_range = math.max(h - l, math.max(math.abs(h - nz(c[1], c)), math.abs(l - nz(c[1], c))))
+    atr = ta.rma(true_range, len) // Wilder's Smoothing
+    offset = atr * mult
+
+    // 【修正点】: var を使用せず、自己参照 (ts[1]) を使って状態を保持する
+    float ts = na
+    prev_ts = nz(ts[1], c - offset)
+
+    if c > prev_ts and nz(c[1], c) > prev_ts
+        ts := math.max(prev_ts, c - offset)
+    else if c < prev_ts and nz(c[1], c) < prev_ts
+        ts := math.min(prev_ts, c + offset)
+    else
+        if c > prev_ts
+            ts := c - offset
+        else
+            ts := c + offset
+    ts
+
+// =========================================================================
+// 3. MULTI-TIMEFRAME DATA FETCHING
+// =========================================================================
+// Function to determine if currently bullish on a given timeframe
+f_is_bullish(len, mult) =>
+    ts = f_atr_ts(high, low, close, len, mult)
+    close > ts
+
+// Calculate Daily states natively
+tech_d_bull = request.security(i_tech_sym, "D", f_is_bullish(i_tech_d_len, i_tech_d_mult),  lookahead=barmerge.lookahead_on)
+gold_d_bull = request.security(i_gold_sym, "D", f_is_bullish(i_gold_d_len, i_gold_d_mult),  lookahead=barmerge.lookahead_on)
+
+// Fetch finalized Weekly states (using [1] inside the security call to ensure the week is closed)
+tech_w_bull = request.security(i_tech_sym, "W", f_is_bullish(i_tech_w_len, i_tech_w_mult)[1], lookahead=barmerge.lookahead_on)
+gold_w_bull = request.security(i_gold_sym, "W", f_is_bullish(i_gold_w_len, i_gold_w_mult)[1], lookahead=barmerge.lookahead_on)
+
+// =========================================================================
+// 4. PORTFOLIO LOGIC & CONFLICT RESOLUTION
+// =========================================================================
+bull_tech = tech_d_bull and tech_w_bull
+bull_gold = gold_d_bull and gold_w_bull
+
+// State Machine: 0 = 100% Cash, 1 = 100% SOXL, 2 = 100% GDXU
+// 【修正点】: 毎バー評価・上書きされる変数なので var を外す
+int state = 0
+
+if bull_gold
+    state := 2
+else if bull_tech
+    state := 1
+else
+    state := 0
+
+// Detect State Changes
+// 【修正点】: 前のバーでの最終的な state を参照する
+state_changed = state != nz(state[1], 0)
+
+// =========================================================================
+// 5. VISUALIZATION & ALERTS
+// =========================================================================
+color bg_color = state == 2 ? color.new(color.yellow, 80) : state == 1 ? color.new(color.blue, 80) : color.new(color.red, 80)
+bgcolor(bg_color, title="Portfolio Allocation Background")
+
+plot(state, title="Portfolio State (0=Cash, 1=SOXL, 2=GDXU)", color=color.white, style=plot.style_stepline, linewidth=2)
+
+if state_changed
+    if state == 2
+        alert("ACTION REQUIRED: Buy/Hold 100% GDXU. (Gold MTF Bullish)", alert.freq_once_per_bar_close)
+    else if state == 1
+        alert("ACTION REQUIRED: Buy/Hold 100% SOXL. (Tech MTF Bullish)", alert.freq_once_per_bar_close)
+    else
+        alert("ACTION REQUIRED: SELL ALL to 100% CASH. (All Markets Bearish)", alert.freq_once_per_bar_close)

--- a/review.txt
+++ b/review.txt
@@ -1,0 +1,82 @@
+The new script uses this function for trailing stop calculation:
+```pine
+calc_ts(len, mult) =>
+    atr = ta.rma(ta.tr(true), len)
+    offset = atr * mult
+    var float ts = na
+    if na(ts[1])
+        ts := close - offset
+    else
+        if close > ts[1] and close[1] > ts[1]
+            ts := math.max(ts[1], close - offset)
+        else if close < ts[1] and close[1] < ts[1]
+            ts := math.min(ts[1], close + offset)
+        else
+            if close > ts[1]
+                ts := close - offset
+            else
+                ts := close + offset
+    ts
+```
+
+This is the EXACT same issue. `var float ts = na` inside `request.security()`.
+Wait, this script uses `alertcondition()`.
+```pine
+alertcondition(sox_signal and not sox_signal[1], title="SOX Long Entry", message="4D SOX Condition Met: Buy SOXL")
+```
+
+If `calc_ts` is fixed, `sox_signal` will start working.
+With `alertcondition()`, the user must create an alert in TradingView and select the specific alert from the condition dropdown (e.g., "SOX Long Entry").
+
+Let's fix `calc_ts`:
+```pine
+calc_ts(len, mult) =>
+    atr = ta.rma(ta.tr(true), len)
+    offset = atr * mult
+
+    // var を外して状態管理を修復
+    float ts = na
+    prev_ts = nz(ts[1], close - offset)
+
+    if close > prev_ts and nz(close[1], close) > prev_ts
+        ts := math.max(prev_ts, close - offset)
+    else if close < prev_ts and nz(close[1], close) < prev_ts
+        ts := math.min(prev_ts, close + offset)
+    else
+        if close > prev_ts
+            ts := close - offset
+        else
+            ts := close + offset
+    ts
+```
+
+Wait, `ta.tr(true)` is used inside `calc_ts`.
+In Pine Script, `ta.tr` inside a custom function evaluated by `request.security()` correctly uses the HTF's high, low, and close. But `ta.tr(true)` handles `na` values for the previous close automatically, which is fine.
+However, `close` and `close[1]` use the HTF close.
+To be perfectly safe, `nz(close[1], close)` is better than just `close[1]`.
+
+What about `var float eq_port = initial_capital` etc.?
+```pine
+// --- Calculate Equity Curves ---
+var float eq_port = initial_capital
+var float eq_sox = initial_capital
+var float eq_gld = initial_capital
+```
+These are calculated on the main chart timeframe (not inside `request.security()`). Using `var` here is perfectly correct! It accumulates the equity over time.
+However, `eq_port := eq_port * (1 + port_ret)` uses `:=` which correctly updates the `var` variable across bars. This is fine.
+
+Are there any other issues?
+```pine
+sox_w_bull = request.security(sym_sox_sig, "W", calc_bull_signal(sox_w_len, sox_w_mult), lookahead=barmerge.lookahead_off)
+sox_d_bull = request.security(sym_sox_sig, "D", calc_bull_signal(sox_d_len, sox_d_mult), lookahead=barmerge.lookahead_off)
+```
+Using `lookahead=barmerge.lookahead_off`. This means the daily and weekly signals will repaint intraday on the current bar but will not look into the future historically. This is standard behavior for `request.security`. The HTF data updates dynamically on every LTF tick.
+Since they use `alertcondition()`, which triggers by default "Once per bar" or "Once per bar close" depending on how the user sets it up in the UI, this is also fine.
+
+One key difference to explain to the Japanese user:
+In the first code, they used `alert("...", alert.freq_once_per_bar_close)`. That requires "Any alert() function call".
+In this new code, they use `alertcondition(...)`. For `alertcondition`, they MUST NOT select "Any alert() function call". Instead, they must create 4 separate alerts, selecting "SOX Long Entry", "SOX Long Exit", "GLD Long Entry", and "GLD Long Exit" individually from the dropdown menu in the Alert dialog box. If they select "Any alert() function call", nothing will happen because `alertcondition` does not trigger `alert()`.
+
+So, the explanation should be:
+1. The root cause is exactly the same as the previous one: `var float ts = na` inside `request.security()`. It needs to be removed.
+2. The method of setting the alert in TradingView is different for this script. Because this script uses `alertcondition` instead of `alert`, the user needs to create an alert for EACH condition from the dropdown menu, not "Any alert() function call".


### PR DESCRIPTION
Resolves an issue where TradingView alerts would not trigger due to `var` keyword limitations inside `request.security()`.

The custom trailing stop function (`f_atr_ts`) initialized a `var float ts = na`. When evaluated across multiple timeframes inside `request.security()`, Pine Script v5 fails to maintain this variable's historical state (`ts[1]`) correctly, leading to `na` values cascading through the boolean logic. Consequently, `state` never correctly changed, silencing all alerts.

The script was corrected by removing `var` and using standard historical fallback `nz(ts[1])` to calculate state properly inside `request.security()`. Additionally, an unnecessary `var` on the `state` variable was removed since it is overwritten every bar. Explanation provided to user in Japanese.

---
*PR created automatically by Jules for task [4654307291757204124](https://jules.google.com/task/4654307291757204124) started by @turnDeep*